### PR TITLE
Removed automatic bonding

### DIFF
--- a/Project-nRF52833/main.c
+++ b/Project-nRF52833/main.c
@@ -680,7 +680,7 @@ static void ble_evt_handler(ble_evt_t const * p_ble_evt, void * p_context)
 {
     uint32_t err_code;
 
-    pm_handler_secure_on_connection(p_ble_evt);
+//     pm_handler_secure_on_connection(p_ble_evt);
 
     switch (p_ble_evt->header.evt_id)
     {


### PR DESCRIPTION
Due to some bugs which make the bonding process when using the nRF52833 takes several seconds to success, automatic bonding is removed.